### PR TITLE
Support maintaining original file UID/GID

### DIFF
--- a/custom_components/config_editor/__init__.py
+++ b/custom_components/config_editor/__init__.py
@@ -86,14 +86,20 @@ async def websocket_create(hass, connection, msg):
             if not os.path.isdir(dirnm):
                 os.makedirs(dirnm, exist_ok=True)
             try:
-                mode = os.stat(fullpath).st_mode
+                statres = os.stat(fullpath)
+                mode = statres.st_mode
+                uid = statres.st_uid
+                gid = statres.st_gid
             except:
                 mode = 0o666
+                uid = 0
+                gid = 0
             with AtomicWriter(fullpath, overwrite=True).open() as fdesc:
                 fdesc.write(content)
             with open(fullpath, 'a') as fdesc:
                 try:
                     os.fchmod(fdesc.fileno(), mode)
+                    os.fchown(fdesc.fileno(), uid, gid)
                 except:
                     pass
         except:


### PR DESCRIPTION
Simple modification to maintain original file UID/GID. In cases where file may be owned by another user, currently this overwrites the user with whomever is running home assistant, often root in the case of Docker. This can be very frustrating to people who use another file editor most of the time and use config editor for quicker changes.